### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
ClearDB의 기본 mysql 버전이 `5.6`이라서 빌드에 문제가 생겼던 것 같다. 
article_comment의 content의 인덱스 사이즈가 500으로 너무 커서 `5.6`버전에서는 문제 발생

기본 버전이 `8.0`인 JawDB로 add-on 변경하고 환경변수를 업데이트함. 

fixes #46